### PR TITLE
MNIST: Replace dots with hyphens in dataset filenames

### DIFF
--- a/src/data/mnist.rs
+++ b/src/data/mnist.rs
@@ -20,19 +20,19 @@ impl Mnist {
 
 	pub fn training<P: AsRef<Path>>(folder_path: P) -> Self {
 		let folder_path = folder_path.as_ref();
-		let err = "Pass a folder containing 'train-images.idx3-ubyte' and 'train-labels.idx1-ubyte'";
+		let err = "Pass a folder containing 'train-images-idx3-ubyte' and 'train-labels-idx1-ubyte'";
 		assert!(folder_path.is_dir(), err);
-		let label_file = File::open(folder_path.join("train-labels.idx1-ubyte").as_path()).expect(err);
-		let image_file = File::open(folder_path.join("train-images.idx3-ubyte").as_path()).expect(err);
+		let label_file = File::open(folder_path.join("train-labels-idx1-ubyte").as_path()).expect(err);
+		let image_file = File::open(folder_path.join("train-images-idx3-ubyte").as_path()).expect(err);
 		Mnist::new(image_file, label_file)
 	}
 
 	pub fn testing<P: AsRef<Path>>(folder_path: P) -> Self {
 		let folder_path = folder_path.as_ref();
-		let err = "Pass a folder containing 't10k-images.idx3-ubyte' and 't10k-labels.idx1-ubyte'";
+		let err = "Pass a folder containing 't10k-images-idx3-ubyte' and 't10k-labels-idx1-ubyte'";
 		assert!(folder_path.is_dir(), err);
-		let label_file = File::open(folder_path.join("t10k-labels.idx1-ubyte").as_path()).expect(err);
-		let image_file = File::open(folder_path.join("t10k-images.idx3-ubyte").as_path()).expect(err);
+		let label_file = File::open(folder_path.join("t10k-labels-idx1-ubyte").as_path()).expect(err);
+		let image_file = File::open(folder_path.join("t10k-images-idx3-ubyte").as_path()).expect(err);
 		Mnist::new(image_file, label_file)
 	}
 }


### PR DESCRIPTION
The original filenames as downloaded from http://yann.lecun.com/exdb/mnist/ don't contain dots in their filename but hyphens.

Here's a screenshot of the website:
![mnist_filenames](https://user-images.githubusercontent.com/112988/44694695-021d4600-aa3d-11e8-97cc-c512139c87ca.png)

[Even in 2004](https://web.archive.org/web/20031203031544/http://yann.lecun.com:80/exdb/mnist/) was the hyphen used for the filenames rather than dots. I suspect an application did not liked handling files without extensions...

This PR simply changes the expected file names to be loaded to contain hyphens.